### PR TITLE
feat: add RegisterFS function for embedded manifest registration

### DIFF
--- a/pkg/cli/manifest/registerfs.go
+++ b/pkg/cli/manifest/registerfs.go
@@ -34,8 +34,8 @@ type DefaultsConfig struct {
 	DefaultRegistration []string `yaml:"defaultRegistration"`
 }
 
-// RegisterFS reads defaults.yaml from the provided fs.FS and returns the parsed,
-// validated, and merged resource providers for default registration.
+// LoadDefaultManifests reads defaults.yaml from the provided fs.FS and returns the
+// parsed, validated, and merged resource providers for default registration.
 //
 // The function performs the following steps:
 //  1. Reads defaults.yaml from the embedded filesystem to get the list of resource
@@ -53,7 +53,7 @@ type DefaultsConfig struct {
 //
 // Returns nil, nil if defaults.yaml has no entries. Returns an error if any step
 // fails (missing files, parse errors, validation failures, namespace mismatches).
-func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
+func LoadDefaultManifests(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
 	// Read the defaults configuration that lists which resource types to register.
 	data, err := fs.ReadFile(fsys, "defaults.yaml")
 	if err != nil {

--- a/pkg/cli/manifest/registerfs.go
+++ b/pkg/cli/manifest/registerfs.go
@@ -29,12 +29,12 @@ import (
 // DefaultsConfig represents the structure of the defaults.yaml configuration file
 // that lists which resource type manifests should be registered by default.
 type DefaultsConfig struct {
-	// DefaultRegistration is a list of canonical resource type names to register.
+	// DefaultRegistration is a list of resource type names to register.
 	// Each entry uses the format Radius.<Namespace>/<typeName> (e.g., Radius.Compute/containers).
 	DefaultRegistration []string `yaml:"defaultRegistration"`
 }
 
-// RegisterFS reads defaults.yaml from the provided fs.FS, resolves each canonical
+// RegisterFS reads defaults.yaml from the provided fs.FS, resolves each
 // resource type name to its manifest file path, parses and validates each manifest,
 // merges manifests sharing a namespace into a single ResourceProvider, and returns
 // the merged providers.

--- a/pkg/cli/manifest/registerfs.go
+++ b/pkg/cli/manifest/registerfs.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+
+	yaml "github.com/goccy/go-yaml"
+)
+
+// DefaultsConfig represents the structure of the defaults.yaml configuration file
+// that lists which resource type manifests should be registered by default.
+type DefaultsConfig struct {
+	// DefaultRegistration is a list of manifest file paths to register.
+	DefaultRegistration []string `yaml:"defaultRegistration"`
+}
+
+// RegisterFS reads defaults.yaml from the provided fs.FS, parses and validates each
+// listed manifest, merges manifests sharing a namespace into a single ResourceProvider,
+// and returns the merged providers.
+func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
+	data, err := fs.ReadFile(fsys, "defaults.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read defaults.yaml: %w", err)
+	}
+
+	config := DefaultsConfig{}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&config); err != nil {
+		return nil, fmt.Errorf("failed to parse defaults.yaml: %w", err)
+	}
+
+	if len(config.DefaultRegistration) == 0 {
+		return nil, nil
+	}
+
+	// Parse and validate each manifest, merging by namespace.
+	merged := map[string]*ResourceProvider{}
+	for _, path := range config.DefaultRegistration {
+		manifestData, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read manifest %s listed in defaults.yaml: %w", path, err)
+		}
+
+		provider, err := ReadBytes(manifestData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse manifest %s: %w", path, err)
+		}
+
+		if err := validateManifestSchemas(ctx, provider); err != nil {
+			return nil, fmt.Errorf("failed to validate manifest %s: %w", path, err)
+		}
+
+		if existing, ok := merged[provider.Namespace]; ok {
+			for typeName, resourceType := range provider.Types {
+				existing.Types[typeName] = resourceType
+			}
+		} else {
+			merged[provider.Namespace] = provider
+		}
+	}
+
+	result := make([]ResourceProvider, 0, len(merged))
+	for _, provider := range merged {
+		result = append(result, *provider)
+	}
+
+	return result, nil
+}

--- a/pkg/cli/manifest/registerfs.go
+++ b/pkg/cli/manifest/registerfs.go
@@ -30,7 +30,7 @@ import (
 // that lists which resource type manifests should be registered by default.
 type DefaultsConfig struct {
 	// DefaultRegistration is a list of canonical resource type names to register.
-	// Each entry uses the format <namespace>/<typeName> (e.g., Radius.Compute/containers).
+	// Each entry uses the format Radius.<Namespace>/<typeName> (e.g., Radius.Compute/containers).
 	DefaultRegistration []string `yaml:"defaultRegistration"`
 }
 
@@ -45,7 +45,7 @@ func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
 	}
 
 	config := DefaultsConfig{}
-	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder := yaml.NewDecoder(bytes.NewReader(data), yaml.Strict())
 	if err := decoder.Decode(&config); err != nil {
 		return nil, fmt.Errorf("failed to parse defaults.yaml: %w", err)
 	}
@@ -70,6 +70,14 @@ func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
 		provider, err := ReadBytes(manifestData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse manifest %s: %w", path, err)
+		}
+
+		// Validate the manifest namespace matches the expected namespace from the
+		// canonical resource type name (e.g., Radius.Compute/containers expects
+		// namespace Radius.Compute).
+		expectedNamespace := strings.SplitN(name, "/", 2)[0]
+		if provider.Namespace != expectedNamespace {
+			return nil, fmt.Errorf("manifest %s declares namespace %q but expected %q from defaults.yaml entry %s", path, provider.Namespace, expectedNamespace, name)
 		}
 
 		if err := validateManifestSchemas(ctx, provider); err != nil {

--- a/pkg/cli/manifest/registerfs.go
+++ b/pkg/cli/manifest/registerfs.go
@@ -45,8 +45,10 @@ type DefaultsConfig struct {
 //  3. Reads and parses each manifest using the existing ReadBytes function.
 //  4. Validates that the manifest's namespace matches the expected namespace
 //     derived from the resource type name.
-//  5. Validates schemas using the existing validateManifestSchemas function.
-//  6. Merges manifests sharing a namespace into a single ResourceProvider
+//  5. Validates that the manifest contains the expected resource type in its
+//     types map.
+//  6. Validates schemas using the existing validateManifestSchemas function.
+//  7. Merges manifests sharing a namespace into a single ResourceProvider
 //     (e.g., three Radius.Compute manifests become one provider with all types).
 //
 // Returns nil, nil if defaults.yaml has no entries. Returns an error if any step
@@ -94,9 +96,17 @@ func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
 		// Validate the manifest namespace matches the expected namespace from the
 		// resource type name (e.g., Radius.Compute/containers expects
 		// namespace Radius.Compute).
-		expectedNamespace := strings.SplitN(name, "/", 2)[0]
+		parts := strings.SplitN(name, "/", 2)
+		expectedNamespace := parts[0]
+		expectedTypeName := parts[1]
+
 		if provider.Namespace != expectedNamespace {
 			return nil, fmt.Errorf("manifest %s declares namespace %q but expected %q from defaults.yaml entry %s", path, provider.Namespace, expectedNamespace, name)
+		}
+
+		// Validate the manifest contains the expected resource type.
+		if _, ok := provider.Types[expectedTypeName]; !ok {
+			return nil, fmt.Errorf("manifest %s does not define resource type %q listed in defaults.yaml entry %s", path, expectedTypeName, name)
 		}
 
 		// Validate the manifest schemas against OpenAPI format.

--- a/pkg/cli/manifest/registerfs.go
+++ b/pkg/cli/manifest/registerfs.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"strings"
 
 	yaml "github.com/goccy/go-yaml"
 )
@@ -28,13 +29,15 @@ import (
 // DefaultsConfig represents the structure of the defaults.yaml configuration file
 // that lists which resource type manifests should be registered by default.
 type DefaultsConfig struct {
-	// DefaultRegistration is a list of manifest file paths to register.
+	// DefaultRegistration is a list of canonical resource type names to register.
+	// Each entry uses the format <namespace>/<typeName> (e.g., Radius.Compute/containers).
 	DefaultRegistration []string `yaml:"defaultRegistration"`
 }
 
-// RegisterFS reads defaults.yaml from the provided fs.FS, parses and validates each
-// listed manifest, merges manifests sharing a namespace into a single ResourceProvider,
-// and returns the merged providers.
+// RegisterFS reads defaults.yaml from the provided fs.FS, resolves each canonical
+// resource type name to its manifest file path, parses and validates each manifest,
+// merges manifests sharing a namespace into a single ResourceProvider, and returns
+// the merged providers.
 func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
 	data, err := fs.ReadFile(fsys, "defaults.yaml")
 	if err != nil {
@@ -53,10 +56,15 @@ func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
 
 	// Parse and validate each manifest, merging by namespace.
 	merged := map[string]*ResourceProvider{}
-	for _, path := range config.DefaultRegistration {
+	for _, name := range config.DefaultRegistration {
+		path, err := resolveResourceTypePath(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve resource type %s: %w", name, err)
+		}
+
 		manifestData, err := fs.ReadFile(fsys, path)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read manifest %s listed in defaults.yaml: %w", path, err)
+			return nil, fmt.Errorf("failed to read manifest for %s (resolved to %s): %w", name, path, err)
 		}
 
 		provider, err := ReadBytes(manifestData)
@@ -83,4 +91,26 @@ func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
 	}
 
 	return result, nil
+}
+
+// resolveResourceTypePath converts a canonical resource type name to a file path.
+// Format: Radius.<Namespace>/<typeName> -> <Namespace>/<typeName>/<typeName>.yaml
+// Example: Radius.Compute/containers -> Compute/containers/containers.yaml
+func resolveResourceTypePath(name string) (string, error) {
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid resource type name %q: expected format Radius.<Namespace>/<typeName>", name)
+	}
+
+	namespace := parts[0]
+	typeName := parts[1]
+
+	if !strings.HasPrefix(namespace, "Radius.") {
+		return "", fmt.Errorf("invalid namespace %q: must start with 'Radius.'", namespace)
+	}
+
+	// Strip "Radius." prefix
+	namespaceSuffix := strings.TrimPrefix(namespace, "Radius.")
+
+	return fmt.Sprintf("%s/%s/%s.yaml", namespaceSuffix, typeName, typeName), nil
 }

--- a/pkg/cli/manifest/registerfs.go
+++ b/pkg/cli/manifest/registerfs.go
@@ -34,16 +34,31 @@ type DefaultsConfig struct {
 	DefaultRegistration []string `yaml:"defaultRegistration"`
 }
 
-// RegisterFS reads defaults.yaml from the provided fs.FS, resolves each
-// resource type name to its manifest file path, parses and validates each manifest,
-// merges manifests sharing a namespace into a single ResourceProvider, and returns
-// the merged providers.
+// RegisterFS reads defaults.yaml from the provided fs.FS and returns the parsed,
+// validated, and merged resource providers for default registration.
+//
+// The function performs the following steps:
+//  1. Reads defaults.yaml from the embedded filesystem to get the list of resource
+//     type names (e.g., Radius.Compute/containers).
+//  2. Resolves each name to a manifest file path using the naming convention:
+//     strip the "Radius." prefix, then <Namespace>/<typeName>/<typeName>.yaml.
+//  3. Reads and parses each manifest using the existing ReadBytes function.
+//  4. Validates that the manifest's namespace matches the expected namespace
+//     derived from the resource type name.
+//  5. Validates schemas using the existing validateManifestSchemas function.
+//  6. Merges manifests sharing a namespace into a single ResourceProvider
+//     (e.g., three Radius.Compute manifests become one provider with all types).
+//
+// Returns nil, nil if defaults.yaml has no entries. Returns an error if any step
+// fails (missing files, parse errors, validation failures, namespace mismatches).
 func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
+	// Read the defaults configuration that lists which resource types to register.
 	data, err := fs.ReadFile(fsys, "defaults.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("failed to read defaults.yaml: %w", err)
 	}
 
+	// Parse defaults.yaml with strict mode to catch typos in field names.
 	config := DefaultsConfig{}
 	decoder := yaml.NewDecoder(bytes.NewReader(data), yaml.Strict())
 	if err := decoder.Decode(&config); err != nil {
@@ -54,14 +69,18 @@ func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
 		return nil, nil
 	}
 
-	// Parse and validate each manifest, merging by namespace.
+	// Parse and validate each manifest, merging providers that share a namespace.
+	// For example, Radius.Compute/containers and Radius.Compute/routes both belong
+	// to the Radius.Compute namespace and are merged into a single ResourceProvider.
 	merged := map[string]*ResourceProvider{}
 	for _, name := range config.DefaultRegistration {
+		// Resolve the resource type name to a file path.
 		path, err := resolveResourceTypePath(name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve resource type %s: %w", name, err)
 		}
 
+		// Read and parse the manifest file.
 		manifestData, err := fs.ReadFile(fsys, path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read manifest for %s (resolved to %s): %w", name, path, err)
@@ -73,17 +92,19 @@ func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
 		}
 
 		// Validate the manifest namespace matches the expected namespace from the
-		// canonical resource type name (e.g., Radius.Compute/containers expects
+		// resource type name (e.g., Radius.Compute/containers expects
 		// namespace Radius.Compute).
 		expectedNamespace := strings.SplitN(name, "/", 2)[0]
 		if provider.Namespace != expectedNamespace {
 			return nil, fmt.Errorf("manifest %s declares namespace %q but expected %q from defaults.yaml entry %s", path, provider.Namespace, expectedNamespace, name)
 		}
 
+		// Validate the manifest schemas against OpenAPI format.
 		if err := validateManifestSchemas(ctx, provider); err != nil {
 			return nil, fmt.Errorf("failed to validate manifest %s: %w", path, err)
 		}
 
+		// Merge into existing provider for this namespace, or create a new one.
 		if existing, ok := merged[provider.Namespace]; ok {
 			for typeName, resourceType := range provider.Types {
 				existing.Types[typeName] = resourceType
@@ -101,7 +122,7 @@ func RegisterFS(ctx context.Context, fsys fs.FS) ([]ResourceProvider, error) {
 	return result, nil
 }
 
-// resolveResourceTypePath converts a canonical resource type name to a file path.
+// resolveResourceTypePath converts a resource type name to a file path.
 // Format: Radius.<Namespace>/<typeName> -> <Namespace>/<typeName>/<typeName>.yaml
 // Example: Radius.Compute/containers -> Compute/containers/containers.yaml
 func resolveResourceTypePath(name string) (string, error) {

--- a/pkg/cli/manifest/registerfs_test.go
+++ b/pkg/cli/manifest/registerfs_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegisterFS(t *testing.T) {
+func TestLoadDefaultManifests(t *testing.T) {
 	t.Parallel()
 
 	validManifest1 := `
@@ -68,7 +68,7 @@ types:
 			"Security/secrets/secrets.yaml":       &fstest.MapFile{Data: []byte(validManifest3)},
 		}
 
-		providers, err := RegisterFS(context.Background(), fsys)
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
 		require.NoError(t, err)
 		require.Len(t, providers, 2)
 
@@ -98,7 +98,7 @@ types:
 
 		fsys := fstest.MapFS{}
 
-		providers, err := RegisterFS(context.Background(), fsys)
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to read defaults.yaml")
 		assert.Nil(t, providers)
@@ -113,7 +113,7 @@ types:
 			},
 		}
 
-		providers, err := RegisterFS(context.Background(), fsys)
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
 		require.NoError(t, err)
 		assert.Nil(t, providers)
 	})
@@ -129,7 +129,7 @@ types:
 			},
 		}
 
-		providers, err := RegisterFS(context.Background(), fsys)
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to read manifest for Radius.Compute/nonexistent")
 		assert.Nil(t, providers)
@@ -147,7 +147,7 @@ types:
 			"Bad/thing/thing.yaml": &fstest.MapFile{Data: []byte("invalid: yaml: [")},
 		}
 
-		providers, err := RegisterFS(context.Background(), fsys)
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse manifest")
 		assert.Nil(t, providers)
@@ -164,7 +164,7 @@ types:
 			},
 		}
 
-		providers, err := RegisterFS(context.Background(), fsys)
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid resource type name")
 		assert.Nil(t, providers)
@@ -181,7 +181,7 @@ types:
 			},
 		}
 
-		providers, err := RegisterFS(context.Background(), fsys)
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must start with 'Radius.'")
 		assert.Nil(t, providers)
@@ -207,7 +207,7 @@ types:
 			"Compute/containers/containers.yaml": &fstest.MapFile{Data: []byte(mismatchedManifest)},
 		}
 
-		providers, err := RegisterFS(context.Background(), fsys)
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "declares namespace")
 		assert.Contains(t, err.Error(), "expected")
@@ -235,7 +235,7 @@ types:
 			"Compute/containers/containers.yaml": &fstest.MapFile{Data: []byte(wrongTypeManifest)},
 		}
 
-		providers, err := RegisterFS(context.Background(), fsys)
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does not define resource type")
 		assert.Contains(t, err.Error(), "containers")
@@ -254,7 +254,7 @@ types:
 			"Security/secrets/secrets.yaml": &fstest.MapFile{Data: []byte(validManifest3)},
 		}
 
-		providers, err := RegisterFS(context.Background(), fsys)
+		providers, err := LoadDefaultManifests(context.Background(), fsys)
 		require.NoError(t, err)
 		require.Len(t, providers, 1)
 		assert.Equal(t, "Radius.Security", providers[0].Namespace)

--- a/pkg/cli/manifest/registerfs_test.go
+++ b/pkg/cli/manifest/registerfs_test.go
@@ -58,9 +58,9 @@ types:
 		fsys := fstest.MapFS{
 			"defaults.yaml": &fstest.MapFile{
 				Data: []byte(`defaultRegistration:
-  - Compute/containers/containers.yaml
-  - Compute/routes/routes.yaml
-  - Security/secrets/secrets.yaml
+  - Radius.Compute/containers
+  - Radius.Compute/routes
+  - Radius.Security/secrets
 `),
 			},
 			"Compute/containers/containers.yaml": &fstest.MapFile{Data: []byte(validManifest1)},
@@ -118,20 +118,20 @@ types:
 		assert.Nil(t, providers)
 	})
 
-	t.Run("returns error when manifest path is missing from FS", func(t *testing.T) {
+	t.Run("returns error when manifest file is missing from FS", func(t *testing.T) {
 		t.Parallel()
 
 		fsys := fstest.MapFS{
 			"defaults.yaml": &fstest.MapFile{
 				Data: []byte(`defaultRegistration:
-  - nonexistent.yaml
+  - Radius.Compute/nonexistent
 `),
 			},
 		}
 
 		providers, err := RegisterFS(context.Background(), fsys)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to read manifest nonexistent.yaml listed in defaults.yaml")
+		assert.Contains(t, err.Error(), "failed to read manifest for Radius.Compute/nonexistent")
 		assert.Nil(t, providers)
 	})
 
@@ -141,15 +141,49 @@ types:
 		fsys := fstest.MapFS{
 			"defaults.yaml": &fstest.MapFile{
 				Data: []byte(`defaultRegistration:
-  - bad.yaml
+  - Radius.Bad/thing
 `),
 			},
-			"bad.yaml": &fstest.MapFile{Data: []byte("invalid: yaml: [")},
+			"Bad/thing/thing.yaml": &fstest.MapFile{Data: []byte("invalid: yaml: [")},
 		}
 
 		providers, err := RegisterFS(context.Background(), fsys)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to parse manifest bad.yaml")
+		assert.Contains(t, err.Error(), "failed to parse manifest")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns error for invalid resource type name format", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - InvalidFormat
+`),
+			},
+		}
+
+		providers, err := RegisterFS(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid resource type name")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns error for non-Radius namespace", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Other.Compute/containers
+`),
+			},
+		}
+
+		providers, err := RegisterFS(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must start with 'Radius.'")
 		assert.Nil(t, providers)
 	})
 
@@ -159,7 +193,7 @@ types:
 		fsys := fstest.MapFS{
 			"defaults.yaml": &fstest.MapFile{
 				Data: []byte(`defaultRegistration:
-  - Security/secrets/secrets.yaml
+  - Radius.Security/secrets
 `),
 			},
 			"Security/secrets/secrets.yaml": &fstest.MapFile{Data: []byte(validManifest3)},
@@ -171,4 +205,55 @@ types:
 		assert.Equal(t, "Radius.Security", providers[0].Namespace)
 		assert.Contains(t, providers[0].Types, "secrets")
 	})
+}
+
+func TestResolveResourceTypePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "standard resource type",
+			input:    "Radius.Compute/containers",
+			expected: "Compute/containers/containers.yaml",
+		},
+		{
+			name:     "nested namespace",
+			input:    "Radius.Security/secrets",
+			expected: "Security/secrets/secrets.yaml",
+		},
+		{
+			name:     "data namespace",
+			input:    "Radius.Data/mySqlDatabases",
+			expected: "Data/mySqlDatabases/mySqlDatabases.yaml",
+		},
+		{
+			name:        "missing slash",
+			input:       "Radius.Compute",
+			expectError: true,
+		},
+		{
+			name:        "non-Radius namespace",
+			input:       "Other.Compute/containers",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := resolveResourceTypePath(tt.input)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
 }

--- a/pkg/cli/manifest/registerfs_test.go
+++ b/pkg/cli/manifest/registerfs_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2023 The Radius Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"context"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterFS(t *testing.T) {
+	t.Parallel()
+
+	validManifest1 := `
+namespace: Radius.Compute
+types:
+  containers:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}`
+
+	validManifest2 := `
+namespace: Radius.Compute
+types:
+  routes:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}`
+
+	validManifest3 := `
+namespace: Radius.Security
+types:
+  secrets:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}`
+
+	t.Run("merges manifests sharing a namespace", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Compute/containers/containers.yaml
+  - Compute/routes/routes.yaml
+  - Security/secrets/secrets.yaml
+`),
+			},
+			"Compute/containers/containers.yaml": &fstest.MapFile{Data: []byte(validManifest1)},
+			"Compute/routes/routes.yaml":         &fstest.MapFile{Data: []byte(validManifest2)},
+			"Security/secrets/secrets.yaml":       &fstest.MapFile{Data: []byte(validManifest3)},
+		}
+
+		providers, err := RegisterFS(context.Background(), fsys)
+		require.NoError(t, err)
+		require.Len(t, providers, 2)
+
+		var computeProvider *ResourceProvider
+		var securityProvider *ResourceProvider
+		for i := range providers {
+			switch providers[i].Namespace {
+			case "Radius.Compute":
+				computeProvider = &providers[i]
+			case "Radius.Security":
+				securityProvider = &providers[i]
+			}
+		}
+
+		require.NotNil(t, computeProvider)
+		assert.Len(t, computeProvider.Types, 2)
+		assert.Contains(t, computeProvider.Types, "containers")
+		assert.Contains(t, computeProvider.Types, "routes")
+
+		require.NotNil(t, securityProvider)
+		assert.Len(t, securityProvider.Types, 1)
+		assert.Contains(t, securityProvider.Types, "secrets")
+	})
+
+	t.Run("returns error when defaults.yaml is missing", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{}
+
+		providers, err := RegisterFS(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read defaults.yaml")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns nil when defaults.yaml has no entries", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte("defaultRegistration:\n"),
+			},
+		}
+
+		providers, err := RegisterFS(context.Background(), fsys)
+		require.NoError(t, err)
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns error when manifest path is missing from FS", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - nonexistent.yaml
+`),
+			},
+		}
+
+		providers, err := RegisterFS(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read manifest nonexistent.yaml listed in defaults.yaml")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns error for invalid manifest YAML", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - bad.yaml
+`),
+			},
+			"bad.yaml": &fstest.MapFile{Data: []byte("invalid: yaml: [")},
+		}
+
+		providers, err := RegisterFS(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse manifest bad.yaml")
+		assert.Nil(t, providers)
+	})
+
+	t.Run("returns single provider without merging", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Security/secrets/secrets.yaml
+`),
+			},
+			"Security/secrets/secrets.yaml": &fstest.MapFile{Data: []byte(validManifest3)},
+		}
+
+		providers, err := RegisterFS(context.Background(), fsys)
+		require.NoError(t, err)
+		require.Len(t, providers, 1)
+		assert.Equal(t, "Radius.Security", providers[0].Namespace)
+		assert.Contains(t, providers[0].Types, "secrets")
+	})
+}

--- a/pkg/cli/manifest/registerfs_test.go
+++ b/pkg/cli/manifest/registerfs_test.go
@@ -214,6 +214,34 @@ types:
 		assert.Nil(t, providers)
 	})
 
+	t.Run("returns error when manifest does not define expected type", func(t *testing.T) {
+		t.Parallel()
+
+		// Manifest declares Radius.Compute namespace but only has 'routes', not 'containers'
+		wrongTypeManifest := `
+namespace: Radius.Compute
+types:
+  routes:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}`
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Radius.Compute/containers
+`),
+			},
+			"Compute/containers/containers.yaml": &fstest.MapFile{Data: []byte(wrongTypeManifest)},
+		}
+
+		providers, err := RegisterFS(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not define resource type")
+		assert.Contains(t, err.Error(), "containers")
+		assert.Nil(t, providers)
+	})
+
 	t.Run("returns single provider without merging", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/cli/manifest/registerfs_test.go
+++ b/pkg/cli/manifest/registerfs_test.go
@@ -187,6 +187,33 @@ types:
 		assert.Nil(t, providers)
 	})
 
+	t.Run("returns error when manifest namespace does not match expected", func(t *testing.T) {
+		t.Parallel()
+
+		mismatchedManifest := `
+namespace: Radius.Other
+types:
+  containers:
+    apiVersions:
+      "2025-08-01-preview":
+        schema: {}`
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - Radius.Compute/containers
+`),
+			},
+			"Compute/containers/containers.yaml": &fstest.MapFile{Data: []byte(mismatchedManifest)},
+		}
+
+		providers, err := RegisterFS(context.Background(), fsys)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "declares namespace")
+		assert.Contains(t, err.Error(), "expected")
+		assert.Nil(t, providers)
+	})
+
 	t.Run("returns single provider without merging", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

Add `RegisterFS` function to the manifest package for parsing and validating resource type manifests from an embedded `fs.FS`.

This is **PR 2 of 4** implementing [automated default registration of resource types from resource-types-contrib](https://github.com/radius-project/radius/blob/main/eng/design-notes/extensibility/2026-04-automated-default-resource-type-registration.md).

## Changes

### New files

- **`pkg/cli/manifest/registerfs.go`**: `RegisterFS` function and `DefaultsConfig` type
- **`pkg/cli/manifest/registerfs_test.go`**: Unit tests

### `RegisterFS` behavior

1. Reads `defaults.yaml` from the provided `fs.FS` to get the list of canonical resource type names
2. For each entry, resolves the name to a manifest file path
3. Reads and parses the manifest using the existing `ReadBytes` function
4. Validates schemas using the existing `validateManifestSchemas` function
5. Merges manifests sharing a namespace (e.g., three `Radius.Compute` files) into a single `ResourceProvider` with all types under one `Types` map
6. Returns the merged providers for the caller to register

### Error handling

| Scenario | Behavior |
|---|---|
| `defaults.yaml` missing from FS | Returns error: `"failed to read defaults.yaml"` |
| Manifest path listed but missing from FS | Returns error: `"failed to read manifest for <name>"` |
| Invalid manifest YAML | Returns parse error with file path |
| Schema validation failure | Returns validation error with file path |
| Empty `defaults.yaml` (no entries) | Returns `nil, nil` |

## Test plan

- Namespace merging: multiple manifests with same namespace produce single provider
- Missing `defaults.yaml`: returns appropriate error
- Empty `defaults.yaml`: returns nil without error
- Missing manifest path: returns appropriate error
- Invalid manifest YAML: returns parse error
- Invalid resource type name format: returns error
- Non-Radius namespace: returns error
- Single provider: no merging needed
- `resolveResourceTypePath` table-driven tests

## Next PRs

- **PR 3**: Update initializer service to accept `fs.FS` and call `RegisterFS`
- **PR 4**: Wire `resource-types-contrib` dependency and remove migrated manifest files