### PR TITLE
feat: update initializer to support embedded resource type manifests

### DIFF
--- a/pkg/ucp/initializer/service.go
+++ b/pkg/ucp/initializer/service.go
@@ -81,7 +81,7 @@ func (w *Service) Run(ctx context.Context) error {
 	// These are the default resource types from resource-types-contrib that are
 	// compiled into the Radius binary via go:embed.
 	if w.embeddedFS != nil {
-		providers, err := manifest.LoadDefaultManifests(ctx, w.embeddedFS)
+		providers, err := manifest.RegisterFS(ctx, w.embeddedFS)
 		if err != nil {
 			return fmt.Errorf("failed to process embedded manifests: %w", err)
 		}

--- a/pkg/ucp/initializer/service.go
+++ b/pkg/ucp/initializer/service.go
@@ -33,6 +33,12 @@ import (
 )
 
 // Service implements the hosting.Service interface for registering manifests.
+// It supports two sources of manifests:
+//   - Embedded manifests from an fs.FS (typically from resource-types-contrib)
+//   - Directory-based manifests from the filesystem (configured via ManifestDirectory)
+//
+// Embedded manifests are processed first. Directory-based manifests are processed
+// second and can override embedded ones via last-write-wins semantics.
 type Service struct {
 	options    *ucp.Options
 	embeddedFS fs.FS
@@ -41,6 +47,7 @@ type Service struct {
 var _ hosting.Service = (*Service)(nil)
 
 // NewService creates a server to register manifests.
+// The embeddedFS parameter is optional; pass nil to skip embedded manifest registration.
 func NewService(options *ucp.Options, embeddedFS fs.FS) *Service {
 	return &Service{
 		options:    options,
@@ -56,12 +63,23 @@ func (s *Service) Name() string {
 func (w *Service) Run(ctx context.Context) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
+	manifestDir := w.options.Config.Initialization.ManifestDirectory
+
+	// If there's nothing to do, return early without initializing the database client.
+	if w.embeddedFS == nil && manifestDir == "" {
+		logger.Info("No embedded manifests or manifest directory specified, initialization is complete")
+		return nil
+	}
+
+	// Initialize the database client only when there is work to do.
 	dbClient, err := w.options.DatabaseProvider.GetClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
-	// Process embedded manifests.
+	// Step 1: Process embedded manifests from the embedded filesystem.
+	// These are the default resource types from resource-types-contrib that are
+	// compiled into the Radius binary via go:embed.
 	if w.embeddedFS != nil {
 		providers, err := manifest.LoadDefaultManifests(ctx, w.embeddedFS)
 		if err != nil {
@@ -80,8 +98,12 @@ func (w *Service) Run(ctx context.Context) error {
 		}
 	}
 
-	// Process directory-based manifests.
-	manifestDir := w.options.Config.Initialization.ManifestDirectory
+	// Step 2: Process directory-based manifests from the filesystem.
+	// These are manifests that require explicit location addresses (e.g., radius_core.yaml,
+	// microsoft_resources.yaml) or are provided as overrides.
+	// Directory-based manifests are processed after embedded ones, so they can override
+	// embedded providers via last-write-wins (registerResourceProviderDirect uses Save
+	// which is a create-or-update operation).
 	if manifestDir == "" {
 		logger.Info("No manifest directory specified, initialization is complete")
 		return nil

--- a/pkg/ucp/initializer/service.go
+++ b/pkg/ucp/initializer/service.go
@@ -63,7 +63,7 @@ func (w *Service) Run(ctx context.Context) error {
 
 	// Process embedded manifests.
 	if w.embeddedFS != nil {
-		providers, err := manifest.RegisterFS(ctx, w.embeddedFS)
+		providers, err := manifest.LoadDefaultManifests(ctx, w.embeddedFS)
 		if err != nil {
 			return fmt.Errorf("failed to process embedded manifests: %w", err)
 		}

--- a/pkg/ucp/initializer/service.go
+++ b/pkg/ucp/initializer/service.go
@@ -19,6 +19,7 @@ package initializer
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -33,15 +34,17 @@ import (
 
 // Service implements the hosting.Service interface for registering manifests.
 type Service struct {
-	options *ucp.Options
+	options    *ucp.Options
+	embeddedFS fs.FS
 }
 
 var _ hosting.Service = (*Service)(nil)
 
 // NewService creates a server to register manifests.
-func NewService(options *ucp.Options) *Service {
+func NewService(options *ucp.Options, embeddedFS fs.FS) *Service {
 	return &Service{
-		options: options,
+		options:    options,
+		embeddedFS: embeddedFS,
 	}
 }
 
@@ -53,6 +56,31 @@ func (s *Service) Name() string {
 func (w *Service) Run(ctx context.Context) error {
 	logger := ucplog.FromContextOrDiscard(ctx)
 
+	dbClient, err := w.options.DatabaseProvider.GetClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get database client: %w", err)
+	}
+
+	// Process embedded manifests.
+	if w.embeddedFS != nil {
+		providers, err := manifest.RegisterFS(ctx, w.embeddedFS)
+		if err != nil {
+			return fmt.Errorf("failed to process embedded manifests: %w", err)
+		}
+
+		for _, provider := range providers {
+			logger.Info("Registering resource provider from embedded manifests", "namespace", provider.Namespace)
+			if err := registerResourceProviderDirect(ctx, dbClient, "local", provider); err != nil {
+				return fmt.Errorf("failed to register embedded resource provider %s: %w", provider.Namespace, err)
+			}
+		}
+
+		if len(providers) > 0 {
+			logger.Info("Successfully registered default resource type manifests")
+		}
+	}
+
+	// Process directory-based manifests.
 	manifestDir := w.options.Config.Initialization.ManifestDirectory
 	if manifestDir == "" {
 		logger.Info("No manifest directory specified, initialization is complete")
@@ -63,11 +91,6 @@ func (w *Service) Run(ctx context.Context) error {
 		return fmt.Errorf("manifest directory does not exist: %w", err)
 	} else if err != nil {
 		return fmt.Errorf("error checking manifest directory: %w", err)
-	}
-
-	dbClient, err := w.options.DatabaseProvider.GetClient(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get database client: %w", err)
 	}
 
 	files, err := os.ReadDir(manifestDir)

--- a/pkg/ucp/initializer/service.go
+++ b/pkg/ucp/initializer/service.go
@@ -81,7 +81,7 @@ func (w *Service) Run(ctx context.Context) error {
 	// These are the default resource types from resource-types-contrib that are
 	// compiled into the Radius binary via go:embed.
 	if w.embeddedFS != nil {
-		providers, err := manifest.RegisterFS(ctx, w.embeddedFS)
+		providers, err := manifest.LoadDefaultManifests(ctx, w.embeddedFS)
 		if err != nil {
 			return fmt.Errorf("failed to process embedded manifests: %w", err)
 		}

--- a/pkg/ucp/initializer/service_test.go
+++ b/pkg/ucp/initializer/service_test.go
@@ -18,9 +18,11 @@ package initializer
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	v1 "github.com/radius-project/radius/pkg/armrpc/api/v1"
 	"github.com/radius-project/radius/pkg/cli/manifest"
@@ -170,14 +172,14 @@ func Test_Run(t *testing.T) {
 
 	t.Run("no manifest directory skips initialization", func(t *testing.T) {
 		t.Parallel()
-		svc := newTestService("")
+		svc := newTestService("", nil)
 		err := svc.Run(context.Background())
 		require.NoError(t, err)
 	})
 
 	t.Run("missing manifest directory returns error", func(t *testing.T) {
 		t.Parallel()
-		svc := newTestService("/nonexistent/path")
+		svc := newTestService("/nonexistent/path", nil)
 		err := svc.Run(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "manifest directory does not exist")
@@ -201,7 +203,7 @@ types:
 		err := os.WriteFile(filepath.Join(tempDir, "test.yaml"), []byte(manifestContent), 0600)
 		require.NoError(t, err)
 
-		svc := newTestService(tempDir)
+		svc := newTestService(tempDir, nil)
 		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
 		require.NoError(t, err)
 
@@ -212,6 +214,146 @@ types:
 		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Test.Provider")
 		require.NoError(t, err)
 		require.NotNil(t, obj)
+	})
+
+	t.Run("registers embedded manifests", func(t *testing.T) {
+		t.Parallel()
+
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - test.yaml
+`),
+			},
+			"test.yaml": &fstest.MapFile{
+				Data: []byte(`
+namespace: Embedded.Provider
+types:
+  myType:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`),
+			},
+		}
+
+		svc := newTestService("", fsys)
+		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		require.NoError(t, err)
+
+		err = svc.Run(context.Background())
+		require.NoError(t, err)
+
+		// Verify the embedded resource provider was registered
+		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Embedded.Provider")
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+	})
+
+	t.Run("registers both embedded and directory manifests", func(t *testing.T) {
+		t.Parallel()
+
+		// Embedded manifest
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - embedded.yaml
+`),
+			},
+			"embedded.yaml": &fstest.MapFile{
+				Data: []byte(`
+namespace: Embedded.Provider
+types:
+  embeddedType:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`),
+			},
+		}
+
+		// Directory manifest
+		tempDir := t.TempDir()
+		manifestContent := `
+namespace: Directory.Provider
+location:
+  global: "http://localhost:9090"
+types:
+  dirType:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`
+		err := os.WriteFile(filepath.Join(tempDir, "dir.yaml"), []byte(manifestContent), 0600)
+		require.NoError(t, err)
+
+		svc := newTestService(tempDir, fsys)
+		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		require.NoError(t, err)
+
+		err = svc.Run(context.Background())
+		require.NoError(t, err)
+
+		// Both should be registered
+		_, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Embedded.Provider")
+		require.NoError(t, err)
+
+		_, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Directory.Provider")
+		require.NoError(t, err)
+	})
+
+	t.Run("directory manifests override embedded manifests", func(t *testing.T) {
+		t.Parallel()
+
+		// Embedded manifest for Same.Provider with typeA
+		fsys := fstest.MapFS{
+			"defaults.yaml": &fstest.MapFile{
+				Data: []byte(`defaultRegistration:
+  - same.yaml
+`),
+			},
+			"same.yaml": &fstest.MapFile{
+				Data: []byte(`
+namespace: Same.Provider
+types:
+  typeA:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`),
+			},
+		}
+
+		// Directory manifest for Same.Provider with typeB (overrides)
+		tempDir := t.TempDir()
+		manifestContent := `
+namespace: Same.Provider
+location:
+  global: "http://localhost:9090"
+types:
+  typeB:
+    apiVersions:
+      "2025-01-01":
+        schema: {}
+`
+		err := os.WriteFile(filepath.Join(tempDir, "same.yaml"), []byte(manifestContent), 0600)
+		require.NoError(t, err)
+
+		svc := newTestService(tempDir, fsys)
+		dbClient, err := svc.options.DatabaseProvider.GetClient(context.Background())
+		require.NoError(t, err)
+
+		err = svc.Run(context.Background())
+		require.NoError(t, err)
+
+		// The directory manifest overwrites the embedded one (last-write-wins)
+		obj, err := dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Same.Provider")
+		require.NoError(t, err)
+		require.NotNil(t, obj)
+
+		// typeB from directory should exist
+		_, err = dbClient.Get(context.Background(), "/planes/radius/local/providers/System.Resources/resourceProviders/Same.Provider/resourceTypes/typeB")
+		require.NoError(t, err)
 	})
 }
 
@@ -241,17 +383,15 @@ func Test_saveResource(t *testing.T) {
 }
 
 // newTestService creates a Service with in-memory database for testing.
-func newTestService(manifestDir string) *Service {
-	return &Service{
-		options: &ucp.Options{
-			Config: &ucp.Config{
-				Initialization: ucp.InitializationConfig{
-					ManifestDirectory: manifestDir,
-				},
+func newTestService(manifestDir string, embeddedFS fs.FS) *Service {
+	return NewService(&ucp.Options{
+		Config: &ucp.Config{
+			Initialization: ucp.InitializationConfig{
+				ManifestDirectory: manifestDir,
 			},
-			DatabaseProvider: databaseprovider.FromMemory(),
 		},
-	}
+		DatabaseProvider: databaseprovider.FromMemory(),
+	}, embeddedFS)
 }
 
 func createTestResourceProvider() manifest.ResourceProvider {

--- a/pkg/ucp/server/server.go
+++ b/pkg/ucp/server/server.go
@@ -46,7 +46,7 @@ func NewServer(options *ucp.Options) (*hosting.Host, error) {
 		services = append(services, &traceservice.Service{Options: &options.Config.Tracing})
 	}
 
-	services = append(services, initializer.NewService(options))
+	services = append(services, initializer.NewService(options, nil))
 
 	return &hosting.Host{
 		Services: services,


### PR DESCRIPTION
## Summary

Update the UCP initializer service to support embedded resource type manifests via `fs.FS`. When an embedded filesystem is provided, the initializer processes those manifests first, then proceeds with directory-based registration as before.

This is **PR 3 of 4** implementing [automated default registration of resource types from resource-types-contrib](https://github.com/radius-project/radius/blob/main/eng/design-notes/extensibility/2026-04-automated-default-resource-type-registration.md).

## Changes

### `pkg/ucp/initializer/service.go`

- `Service` struct gains `embeddedFS fs.FS` field
- `NewService` accepts an additional `fs.FS` parameter
- `Run()` processes embedded manifests first via `LoadDefaultManifests`, then directory-based manifests
- Embedded providers are registered via `registerResourceProviderDirect` (direct database writes), consistent with existing directory-based registration

### `pkg/ucp/initializer/service_test.go`

- Updated `newTestService` to accept `fs.FS` parameter
- All existing tests pass `nil` for backwards compatibility
- New test: "registers embedded manifests" — verifies embedded FS registration works
- New test: "registers both embedded and directory manifests" — verifies both sources coexist
- New test: "directory manifests override embedded manifests" — verifies last-write-wins behavior

### `pkg/ucp/server/server.go`

- Updated `NewService` call to pass `nil` — **no behavior change** until the wiring PR connects `resource-types-contrib`

## Startup flow after this PR

```
Run()
  |-- if embeddedFS != nil:
  |     |-- manifest.LoadDefaultManifests(ctx, embeddedFS) -> []ResourceProvider
  |     +-- for each provider: registerResourceProviderDirect()
  |
  +-- if manifestDir != "":
        |-- os.ReadDir(manifestDir)
        +-- for each file: ValidateManifest() -> registerResourceProviderDirect()
```

Directory-based manifests can override embedded ones (UCP uses `Save` which is a create-or-update).

## Next PR

- **PR 4**: Wire `resource-types-contrib` dependency, pass `DefaultManifests` in `server.go`, remove migrated manifest files