### PR TITLE
Add resource type sync step to the release process

### DIFF
--- a/docs/contributing/contributing-releases/README.md
+++ b/docs/contributing/contributing-releases/README.md
@@ -128,7 +128,24 @@ git push origin vX.Y.Z-rcN
 
 > **Note**: This manual tagging step is a temporary workaround. Ideally the [Deployment Engine Release Workflow](https://github.com/azure-octo/deployment-engine/actions/workflows/release.yaml) would handle this, but GPG signing is not yet configured there. See [azure-octo/deployment-engine#456](https://github.com/azure-octo/deployment-engine/issues/456).
 
-### Step 3: Update versions.yaml
+### Step 3: Update default resource types
+
+Ensure the default resource type manifests are up to date with the latest `resource-types-contrib` definitions. Run the following from the same branch you will use for the `versions.yaml` update:
+
+```bash
+make update-resource-types
+```
+
+This updates the `resource-types-contrib` dependency in `go.mod` to the latest version and copies the manifest files listed in `deploy/manifest/defaults.yaml` into `deploy/manifest/built-in-providers/`. Review the diff to confirm the changes are expected.
+
+If the update fails or the copied manifests fail schema validation at startup during testing, you have two options:
+
+1. **Fix forward**: Correct the manifest in `resource-types-contrib`, merge the fix, then re-run `make update-resource-types`.
+2. **Pin to last known good version**: Revert the `go.mod` change to keep the previous `resource-types-contrib` version and run `make sync-resource-types` to restore the matching manifests.
+
+Include the updated `go.mod`, `go.sum`, and manifest files in the same PR as the `versions.yaml` change.
+
+### Step 4: Update versions.yaml
 
 Create a branch from `main` in the `radius-project/radius` repo:
 
@@ -151,7 +168,7 @@ deprecated:
     version: 'v0.54.0'
 ```
 
-### Step 4: Merge to main
+### Step 5: Merge to main
 
 Push the branch and create a PR against `main`:
 
@@ -161,12 +178,12 @@ git push origin <USERNAME>/release-X.Y.0-rcN
 
 After approval, merge the PR to `main`.
 
-### Step 5: Verify the automated release
+### Step 6: Verify the automated release
 
 After merging, the [Release Radius](https://github.com/radius-project/radius/actions/workflows/release.yaml) workflow automatically runs because `versions.yaml` changed on `main`.
 
 - **First RC**: The workflow creates the `release/X.Y` branch from `main` and pushes the `vX.Y.Z-rcN` tag. The tag push then triggers the [Build and Test](https://github.com/radius-project/radius/actions/workflows/build.yaml) workflow. No manual tag creation is needed. Verify the release using the checklist below.
-- **Subsequent RCs**: The workflow detects that the release branch already exists and **skips tag creation**. This is expected — the tag will be created when the cherry-pick lands on the release branch in [Step 7](#step-7-cherry-pick-additional-changes-subsequent-rcs-only). Skip ahead to Step 6 for now and return to verify after completing Step 7.
+- **Subsequent RCs**: The workflow detects that the release branch already exists and **skips tag creation**. This is expected — the tag will be created when the cherry-pick lands on the release branch in [Step 8](#step-8-cherry-pick-additional-changes-subsequent-rcs-only). Skip ahead to Step 7 for now and return to verify after completing Step 8.
 
 Monitor and verify:
 
@@ -174,11 +191,11 @@ Monitor and verify:
 2. The [Build and Test](https://github.com/radius-project/radius/actions/workflows/build.yaml) workflow (triggered by the tag push) completes successfully. This workflow also dispatches Bicep types publishing automatically.
 3. An RC release marked as pre-release appears on [GitHub Releases](https://github.com/radius-project/radius/releases).
 
-### Step 6: Publish Bicep recipes
+### Step 7: Publish Bicep recipes
 
 In the `radius-project/resource-types-contrib` repo, manually run the [Publish Bicep Recipes](https://github.com/radius-project/resource-types-contrib/actions/workflows/publish-bicep-recipes.yaml) workflow. Enter the RC version number without the `v` prefix as the release version (e.g., `0.56.0-rc1`).
 
-### Step 7: Cherry-pick additional changes (subsequent RCs only)
+### Step 8: Cherry-pick additional changes (subsequent RCs only)
 
 > **Skip this step for the first RC.** The release branch was just created from `main` and already contains all changes.
 
@@ -200,9 +217,9 @@ Push and create a PR targeting the release branch:
 git push origin <USERNAME>/cherry-pick-rcN-to-release-branch
 ```
 
-After approval, merge the PR. This triggers the release automation on the release branch, creating the new RC tag. Return to [Step 5](#step-5-verify-the-automated-release) to verify the release completed successfully.
+After approval, merge the PR. This triggers the release automation on the release branch, creating the new RC tag. Return to [Step 6](#step-6-verify-the-automated-release) to verify the release completed successfully.
 
-### Step 8: Run validation workflows
+### Step 9: Run validation workflows
 
 1. In `radius-project/radius`, run the [Release verification](https://github.com/radius-project/radius/actions/workflows/release-verification.yaml) workflow from the `release/X.Y` branch. Enter the RC version number without the `v` prefix as the version (e.g., `0.56.0-rc1`).
 
@@ -218,7 +235,7 @@ After approval, merge the PR. This triggers the release automation on the releas
 
    > Run this only after the upmerge PR has been merged to `edge`. If tests fail, check logs and existing issues in the samples repo. Flaky tests may pass on re-run. If failures persist, file an issue and raise it with maintainers.
 
-### Step 9: Assess results
+### Step 10: Assess results
 
 If all validation workflows pass, proceed to [creating the final release](#creating-the-final-release).
 

--- a/docs/contributing/contributing-releases/README.md
+++ b/docs/contributing/contributing-releases/README.md
@@ -130,7 +130,7 @@ git push origin vX.Y.Z-rcN
 
 ### Step 3: Update default resource types
 
-Ensure the default resource type manifests are up to date with the latest `resource-types-contrib` definitions. Run the following from the same branch you will use for the `versions.yaml` update:
+Ensure the default resource type manifests are up to date with the latest `resource-types-contrib` definitions:
 
 ```bash
 make update-resource-types
@@ -143,7 +143,7 @@ If the update fails or the copied manifests fail schema validation at startup du
 1. **Fix forward**: Correct the manifest in `resource-types-contrib`, merge the fix, then re-run `make update-resource-types`.
 2. **Pin to last known good version**: Revert the `go.mod` change to keep the previous `resource-types-contrib` version and run `make sync-resource-types` to restore the matching manifests.
 
-Include the updated `go.mod`, `go.sum`, and manifest files in the same PR as the `versions.yaml` change.
+Open a separate PR with the updated `go.mod`, `go.sum`, and manifest files. Merge it before proceeding to the `versions.yaml` update.
 
 ### Step 4: Update versions.yaml
 


### PR DESCRIPTION
## Overview

Add a new step to the RC release process documenting when and how to run `make update-resource-types` before each release.

This is PR 3 from the [automated default resource type registration design](https://github.com/radius-project/radius/pull/11610/changes).

## Changes

- **Added Step 3: Update default resource types** to the RC release process in `docs/contributing/contributing-releases/README.md`
- Renumbered subsequent steps (4→5, 5→6, etc.) and updated cross-references
- Includes guidance on handling schema validation failures:
  - **Fix forward**: Correct the manifest in `resource-types-contrib`, merge, and re-run `make update-resource-types`
  - **Pin to last known good**: Revert the `go.mod` change and run `make sync-resource-types` to restore matching manifests

## Depends on

- PR 2: Automate default resource type registration (#34)