### PR TITLE
feat: integrate contrib types into unified Bicep extension

### DIFF
--- a/bicep-tools/cmd/manifest-to-bicep/main_test.go
+++ b/bicep-tools/cmd/manifest-to-bicep/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -49,20 +50,17 @@ func TestRunGenerate_MultipleFiles_SameNamespace(t *testing.T) {
 		}
 	}
 
-	// Verify types.json contains definitions from both manifests by checking
-	// that the merged output is larger than a single-manifest output.
-	singleDir := t.TempDir()
-	err = RunGenerate([]string{"testdata/containers.yaml"}, singleDir)
+	// Verify the merged index.json references both resource types.
+	indexContent, err := os.ReadFile(filepath.Join(outputDir, "index.json"))
 	if err != nil {
-		t.Fatalf("RunGenerate (single) returned error: %v", err)
+		t.Fatalf("failed to read index.json: %v", err)
 	}
 
-	mergedTypes, _ := os.ReadFile(filepath.Join(outputDir, "types.json"))
-	singleTypes, _ := os.ReadFile(filepath.Join(singleDir, "types.json"))
-
-	if len(mergedTypes) <= len(singleTypes) {
-		t.Errorf("merged types.json (%d bytes) should be larger than single-manifest types.json (%d bytes)",
-			len(mergedTypes), len(singleTypes))
+	indexStr := string(indexContent)
+	for _, typeName := range []string{"Radius.Compute/containers", "Radius.Compute/routes"} {
+		if !strings.Contains(indexStr, typeName) {
+			t.Errorf("expected index.json to contain %q, but it was not found", typeName)
+		}
 	}
 }
 
@@ -75,8 +73,8 @@ func TestRunGenerate_MultipleFiles_DifferentNamespaces(t *testing.T) {
 	}
 
 	expected := "all manifests must share the same namespace"
-	if got := err.Error(); !contains(got, expected) {
-		t.Errorf("expected error containing %q, got %q", expected, got)
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("expected error containing %q, got %q", expected, err.Error())
 	}
 }
 
@@ -89,8 +87,8 @@ func TestRunGenerate_NonexistentFile(t *testing.T) {
 	}
 
 	expected := "manifest file does not exist"
-	if got := err.Error(); !contains(got, expected) {
-		t.Errorf("expected error containing %q, got %q", expected, got)
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("expected error containing %q, got %q", expected, err.Error())
 	}
 }
 
@@ -103,8 +101,8 @@ func TestRunGenerate_EmptyManifestList(t *testing.T) {
 	}
 
 	expected := "at least one manifest file is required"
-	if got := err.Error(); !contains(got, expected) {
-		t.Errorf("expected error containing %q, got %q", expected, got)
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("expected error containing %q, got %q", expected, err.Error())
 	}
 }
 
@@ -116,20 +114,7 @@ func TestMergeManifestFiles_DuplicateType(t *testing.T) {
 	}
 
 	expected := "duplicate resource type"
-	if got := err.Error(); !contains(got, expected) {
-		t.Errorf("expected error containing %q, got %q", expected, got)
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("expected error containing %q, got %q", expected, err.Error())
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/bicep-tools/cmd/manifest-to-bicep/main_test.go
+++ b/bicep-tools/cmd/manifest-to-bicep/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -50,17 +49,20 @@ func TestRunGenerate_MultipleFiles_SameNamespace(t *testing.T) {
 		}
 	}
 
-	// Verify the merged index.json references both resource types.
-	indexContent, err := os.ReadFile(filepath.Join(outputDir, "index.json"))
+	// Verify types.json contains definitions from both manifests by checking
+	// that the merged output is larger than a single-manifest output.
+	singleDir := t.TempDir()
+	err = RunGenerate([]string{"testdata/containers.yaml"}, singleDir)
 	if err != nil {
-		t.Fatalf("failed to read index.json: %v", err)
+		t.Fatalf("RunGenerate (single) returned error: %v", err)
 	}
 
-	indexStr := string(indexContent)
-	for _, typeName := range []string{"Radius.Compute/containers", "Radius.Compute/routes"} {
-		if !strings.Contains(indexStr, typeName) {
-			t.Errorf("expected index.json to contain %q, but it was not found", typeName)
-		}
+	mergedTypes, _ := os.ReadFile(filepath.Join(outputDir, "types.json"))
+	singleTypes, _ := os.ReadFile(filepath.Join(singleDir, "types.json"))
+
+	if len(mergedTypes) <= len(singleTypes) {
+		t.Errorf("merged types.json (%d bytes) should be larger than single-manifest types.json (%d bytes)",
+			len(mergedTypes), len(singleTypes))
 	}
 }
 
@@ -73,8 +75,8 @@ func TestRunGenerate_MultipleFiles_DifferentNamespaces(t *testing.T) {
 	}
 
 	expected := "all manifests must share the same namespace"
-	if !strings.Contains(err.Error(), expected) {
-		t.Errorf("expected error containing %q, got %q", expected, err.Error())
+	if got := err.Error(); !contains(got, expected) {
+		t.Errorf("expected error containing %q, got %q", expected, got)
 	}
 }
 
@@ -87,8 +89,8 @@ func TestRunGenerate_NonexistentFile(t *testing.T) {
 	}
 
 	expected := "manifest file does not exist"
-	if !strings.Contains(err.Error(), expected) {
-		t.Errorf("expected error containing %q, got %q", expected, err.Error())
+	if got := err.Error(); !contains(got, expected) {
+		t.Errorf("expected error containing %q, got %q", expected, got)
 	}
 }
 
@@ -101,8 +103,8 @@ func TestRunGenerate_EmptyManifestList(t *testing.T) {
 	}
 
 	expected := "at least one manifest file is required"
-	if !strings.Contains(err.Error(), expected) {
-		t.Errorf("expected error containing %q, got %q", expected, err.Error())
+	if got := err.Error(); !contains(got, expected) {
+		t.Errorf("expected error containing %q, got %q", expected, got)
 	}
 }
 
@@ -114,7 +116,20 @@ func TestMergeManifestFiles_DuplicateType(t *testing.T) {
 	}
 
 	expected := "duplicate resource type"
-	if !strings.Contains(err.Error(), expected) {
-		t.Errorf("expected error containing %q, got %q", expected, err.Error())
+	if got := err.Error(); !contains(got, expected) {
+		t.Errorf("expected error containing %q, got %q", expected, got)
 	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
 }

--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -4,9 +4,6 @@
   },
   "extensions": {
     "radius": "br:biceptypes.azurecr.io/radius:latest",
-    "radiusCompute": "br:biceptypes.azurecr.io/radiuscompute:latest",
-    "radiusData": "br:biceptypes.azurecr.io/radiusdata:latest",
-    "radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:latest",
     "aws": "br:biceptypes.azurecr.io/aws:latest"
   }
 }

--- a/build/generate.mk
+++ b/build/generate.mk
@@ -147,6 +147,79 @@ generate-bicep-types: generate-node-installed generate-pnpm-installed ## Generat
 	CI=true pnpm -C hack/bicep-types-radius/src/autorest.bicep install && pnpm -C hack/bicep-types-radius/src/autorest.bicep run build; \
 	echo "Run generator from hack/bicep-types-radius/src/generator dir"; \
 	CI=true pnpm -C hack/bicep-types-radius/src/generator install && pnpm -C hack/bicep-types-radius/src/generator run generate --specs-dir ../../../../swagger --release-version ${VERSION} --verbose
+	@echo "$(ARROW) Generating Bicep types for default contrib resource type namespaces..."
+	@$(MAKE) generate-bicep-types-contrib
+	@echo "$(ARROW) Rebuilding unified Bicep types index..."
+	CI=true pnpm -C hack/bicep-types-radius/src/generator run rebuild-index --release-version ${VERSION}
+
+# Generates Bicep types.json files for the default contrib resource type
+# namespaces listed in deploy/manifest/defaults.yaml.
+#
+# Each entry in defaults.yaml uses <namespace>/<typeName> format
+# (e.g. Radius.Compute/containers). This target:
+#   1. Reads defaults.yaml to discover which types to include.
+#   2. Groups entries by namespace.
+#   3. For each namespace, passes ALL per-type manifest files to
+#      `generate` so they are merged into a single output.
+#
+# Per-type manifest files live under deploy/manifest/built-in-providers/self-hosted/
+# as individual YAML files (e.g. containers.yaml, routes.yaml).
+DEFAULTS_YAML := deploy/manifest/defaults.yaml
+BICEP_TYPES_CONTRIB_API_VERSION ?= 2025-08-01-preview
+BICEP_TYPES_OUTPUT_BASE := hack/bicep-types-radius/generated/radius
+BICEP_TYPES_CONTRIB_MANIFEST_DIR := deploy/manifest/built-in-providers/self-hosted
+
+.PHONY: generate-yq-installed
+generate-yq-installed:
+	@echo "$(ARROW) Detecting yq..."
+	@which yq > /dev/null || { echo "run 'go install github.com/mikefarah/yq/v4@latest' to install yq"; exit 1; }
+	@echo "$(ARROW) OK"
+
+.PHONY: generate-bicep-types-contrib
+generate-bicep-types-contrib: generate-yq-installed ## Generates Bicep types.json files for default contrib namespaces from defaults.yaml.
+	# Discover unique namespaces from defaults.yaml.
+	@NAMESPACES=$$(yq '.defaultRegistration[]' $(DEFAULTS_YAML) | sed 's|/.*||' | sort -u) && \
+	for ns in $$NAMESPACES; do \
+		ns_lower=$$(echo "$$ns" | tr '[:upper:]' '[:lower:]') && \
+		out_dir="$(BICEP_TYPES_OUTPUT_BASE)/$$ns_lower/$(BICEP_TYPES_CONTRIB_API_VERSION)" && \
+		manifest_args="" && \
+		for entry in $$(yq '.defaultRegistration[]' $(DEFAULTS_YAML) | grep "^$$ns/"); do \
+			type_name=$$(echo "$$entry" | cut -d'/' -f2) && \
+			manifest="$(BICEP_TYPES_CONTRIB_MANIFEST_DIR)/$$type_name.yaml" && \
+			if [ ! -f "$$manifest" ]; then \
+				echo "ERROR: Manifest not found: $$manifest (from entry '$$entry')"; \
+				exit 1; \
+			fi && \
+			manifest_args="$$manifest_args $$manifest"; \
+		done && \
+		echo "  -> $$ns ($$manifest_args) -> $$out_dir" && \
+		go run ./bicep-tools/cmd/manifest-to-bicep generate $$manifest_args "$$out_dir" || exit 1; \
+	done
+
+# Publishing the unified `radius` Bicep extension. Runnable locally against any
+# OCI registry (e.g. a local Zot/CRane-backed registry, or biceptypes.azurecr.io
+# after `az acr login`). Both BICEP_PUBLISH_TARGET and the local Bicep CLI must
+# be available. CI workflows (added separately) call this target after
+# generating types and authenticating to the registry.
+#
+# Example:
+#   make publish-bicep-extension BICEP_PUBLISH_TARGET=br:biceptypes.azurecr.io/radius:latest
+BICEP_PUBLISH_INDEX := $(BICEP_TYPES_OUTPUT_BASE)/../index.json
+BICEP_PUBLISH_TARGET ?=
+
+.PHONY: publish-bicep-extension
+publish-bicep-extension: ## Publish the unified `radius` Bicep extension to BICEP_PUBLISH_TARGET. Requires generate-bicep-types to have been run.
+	@if [ -z "$(BICEP_PUBLISH_TARGET)" ]; then \
+		echo "ERROR: BICEP_PUBLISH_TARGET must be set (e.g. br:biceptypes.azurecr.io/radius:latest)"; \
+		exit 1; \
+	fi
+	@if [ ! -f "$(BICEP_PUBLISH_INDEX)" ]; then \
+		echo "ERROR: $(BICEP_PUBLISH_INDEX) does not exist; run 'make generate-bicep-types' first"; \
+		exit 1; \
+	fi
+	@which bicep > /dev/null || { echo "ERROR: 'bicep' CLI not found in PATH"; exit 1; }
+	@echo "$(ARROW) Publishing Bicep extension index $(BICEP_PUBLISH_INDEX) -> $(BICEP_PUBLISH_TARGET)"
+	bicep publish-extension "$(BICEP_PUBLISH_INDEX)" --target "$(BICEP_PUBLISH_TARGET)" --force
 
 
 .PHONY: generate-containerinstance-client

--- a/build/install-bicep.sh
+++ b/build/install-bicep.sh
@@ -45,9 +45,6 @@ cat <<EOF > $OUTPUT_DIR/bicepconfig.json
 {
   "extensions": {
     "radius": "br:biceptypes.azurecr.io/radius:${REL_CHANNEL}",
-    "radiusCompute": "br:biceptypes.azurecr.io/radiuscompute:${REL_CHANNEL}",
-    "radiusData": "br:biceptypes.azurecr.io/radiusdata:${REL_CHANNEL}",
-    "radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:${REL_CHANNEL}",
     "aws": "br:biceptypes.azurecr.io/aws:${REL_CHANNEL}"
   }
 }

--- a/hack/bicep-types-radius/src/generator/package.json
+++ b/hack/bicep-types-radius/src/generator/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "tsc -p .",
     "generate": "ts-node src/cmd/generate.ts",
+    "rebuild-index": "ts-node src/cmd/rebuild-index.ts",
     "lint": "eslint src --ext ts",
     "lint:fix": "eslint src --ext ts --fix",
     "postinstall": "cd node_modules/bicep-types-repo/src/bicep-types && npm install && npm run build && cd ../../../.. && rm -rf node_modules/bicep-types && ln -sf bicep-types-repo/src/bicep-types node_modules/bicep-types"

--- a/hack/bicep-types-radius/src/generator/src/cmd/generate.ts
+++ b/hack/bicep-types-radius/src/generator/src/cmd/generate.ts
@@ -20,14 +20,7 @@ import { mkdir, rm, writeFile, readFile } from "fs/promises";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import { Dictionary } from "lodash";
-import {
-  TypeFile,
-  buildIndex,
-  readTypesJson,
-  writeIndexJson,
-  writeIndexMarkdown,
-  TypeSettings,
-} from "bicep-types";
+import { buildTypeIndex } from "../index-builder";
 import { GeneratorConfig, getConfig } from "../config";
 import * as markdown from "@ts-common/commonmark-to-markdown";
 import * as yaml from "js-yaml";
@@ -312,31 +305,4 @@ async function findReadmePaths(specsPath: string) {
       .split(path.sep)
       .some((parent) => parent == "resource-manager");
   });
-}
-
-async function buildTypeIndex(
-  logger: ILogger,
-  baseDir: string,
-  version: string,
-) {
-  const typesPaths = await findRecursive(baseDir, (filePath) => {
-    return path.basename(filePath) === "types.json";
-  });
-
-  const typeFiles: TypeFile[] = [];
-  for (const typePath of typesPaths) {
-    const content = await readFile(typePath, { encoding: "utf8" });
-    typeFiles.push({
-      relativePath: path.relative(baseDir, typePath),
-      types: readTypesJson(content),
-    });
-  }
-  const indexContent = await buildIndex(
-    typeFiles,
-    (log) => logOut(logger, log),
-    { name: "Radius", version: version, isSingleton: false } as TypeSettings,
-  );
-
-  await writeFile(`${baseDir}/index.json`, writeIndexJson(indexContent));
-  await writeFile(`${baseDir}/index.md`, writeIndexMarkdown(indexContent));
 }

--- a/hack/bicep-types-radius/src/generator/src/cmd/rebuild-index.ts
+++ b/hack/bicep-types-radius/src/generator/src/cmd/rebuild-index.ts
@@ -1,0 +1,55 @@
+// ------------------------------------------------------------
+// Copyright 2023 The Radius Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------.
+//
+// Standalone CLI entry point for rebuilding the unified Bicep types index.
+//
+// This is a thin wrapper around the shared buildTypeIndex() function from
+// index-builder.ts. It exists as a separate entry point so the Makefile can
+// invoke it independently after the Go-based manifest-to-bicep converter has
+// added contrib types.json files to the generated/ tree.
+//
+// Usage:
+//   pnpm run rebuild-index --release-version <version>
+
+import path from "path";
+import yargs from "yargs/yargs";
+import { hideBin } from "yargs/helpers";
+import { buildTypeIndex } from "../index-builder";
+import { defaultLogger, executeSynchronous } from "../utils";
+
+const rootDir = `${__dirname}/../../../../`;
+const defaultOutDir = path.resolve(`${rootDir}/generated`);
+
+const argsConfig = yargs(hideBin(process.argv))
+  .strict()
+  .option("out-dir", {
+    type: "string",
+    default: defaultOutDir,
+    desc: "Output path containing previously generated types.json files",
+  })
+  .option("release-version", {
+    type: "string",
+    default: "latest",
+    desc: "The version reported in the index settings",
+  });
+
+executeSynchronous(async () => {
+  const args = await argsConfig.parseAsync();
+  const outputBaseDir = path.resolve(args["out-dir"]);
+  const version = args["release-version"];
+
+  await buildTypeIndex(defaultLogger, outputBaseDir, version);
+});

--- a/hack/bicep-types-radius/src/generator/src/index-builder.ts
+++ b/hack/bicep-types-radius/src/generator/src/index-builder.ts
@@ -1,0 +1,86 @@
+// ------------------------------------------------------------
+// Copyright 2023 The Radius Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------.
+//
+// Shared module for building the unified Bicep types index (index.json + index.md).
+//
+// This walks a directory tree for types.json files and produces a single
+// index.json that maps resource type names to their type definitions, plus an
+// index.md with human-readable documentation. It is used by:
+//
+//   - generate.ts: at the end of the autorest pipeline to build the initial index.
+//   - rebuild-index.ts: as a standalone step after additional types.json files
+//     (e.g. from the Go-based manifest-to-bicep converter) have been added.
+//
+// Extracting this into a shared module ensures that both callers use the same
+// logic and avoids code duplication.
+
+import path from "path";
+import { readFile, writeFile } from "fs/promises";
+import {
+  TypeFile,
+  buildIndex,
+  readTypesJson,
+  writeIndexJson,
+  writeIndexMarkdown,
+  TypeSettings,
+} from "bicep-types";
+import { findRecursive, ILogger, logOut } from "./utils";
+
+/**
+ * Walks baseDir recursively for types.json files, builds a unified index, and
+ * writes index.json + index.md to baseDir.
+ *
+ * @param logger - Logger instance for diagnostic output.
+ * @param baseDir - Root directory containing the generated types tree (e.g. generated/).
+ * @param version - Version string reported in the index settings (e.g. "latest" or "v0.58.0").
+ */
+export async function buildTypeIndex(
+  logger: ILogger,
+  baseDir: string,
+  version: string,
+) {
+  // Find all types.json files in the generated tree. Each file represents a
+  // single namespace/apiVersion combination (e.g. radius.compute/2025-08-01-preview/types.json).
+  const typesPaths = await findRecursive(baseDir, (filePath) => {
+    return path.basename(filePath) === "types.json";
+  });
+
+  // Read each types.json and collect them as TypeFile entries for the index builder.
+  const typeFiles: TypeFile[] = [];
+  for (const typePath of typesPaths) {
+    const content = await readFile(typePath, { encoding: "utf8" });
+    typeFiles.push({
+      relativePath: path.relative(baseDir, typePath),
+      types: readTypesJson(content),
+    });
+  }
+
+  // Build the unified index from all collected type files.
+  const indexContent = await buildIndex(
+    typeFiles,
+    (log) => logOut(logger, log),
+    { name: "Radius", version: version, isSingleton: false } as TypeSettings,
+  );
+
+  // Write the index files to the base directory.
+  await writeFile(`${baseDir}/index.json`, writeIndexJson(indexContent));
+  await writeFile(`${baseDir}/index.md`, writeIndexMarkdown(indexContent));
+
+  logOut(
+    logger,
+    `Built index from ${typeFiles.length} types.json file(s) in ${baseDir}`,
+  );
+}

--- a/pkg/cli/setup/application.go
+++ b/pkg/cli/setup/application.go
@@ -49,9 +49,6 @@ resource demo 'Applications.Core/containers@2023-10-01-preview' = {
 	bicepConfigTemplate = `{
 	"extensions": {
 		"radius": "br:biceptypes.azurecr.io/radius:%s",
-		"radiusCompute": "br:biceptypes.azurecr.io/radiuscompute:%s",
-		"radiusData": "br:biceptypes.azurecr.io/radiusdata:%s",
-		"radiusSecurity": "br:biceptypes.azurecr.io/radiussecurity:%s",
 		"aws": "br:biceptypes.azurecr.io/aws:%s"
 	}
 }`
@@ -92,5 +89,5 @@ func getVersionedBicepConfig() string {
 		tag = "latest"
 	}
 
-	return fmt.Sprintf(bicepConfigTemplate, tag, tag, tag, tag, tag)
+	return fmt.Sprintf(bicepConfigTemplate, tag, tag)
 }

--- a/pkg/cli/setup/application_test.go
+++ b/pkg/cli/setup/application_test.go
@@ -42,7 +42,7 @@ func Test_ScaffoldApplication_CreatesBothFiles(t *testing.T) {
 
 	b, err = os.ReadFile(filepath.Join(directory, "bicepconfig.json"))
 	require.NoError(t, err)
-	require.Equal(t, fmt.Sprintf(bicepConfigTemplate, latest, latest, latest, latest, latest), string(b))
+	require.Equal(t, fmt.Sprintf(bicepConfigTemplate, latest, latest), string(b))
 }
 
 func Test_ScaffoldApplication_KeepsExistingFiles(t *testing.T) {


### PR DESCRIPTION
## Overview

Today, resource types from `resource-types-contrib` (e.g. `Radius.Compute/containers`, `Radius.Security/secrets`) are published as separate Bicep extensions (`radiusCompute`, `radiusData`, `radiusSecurity`), requiring users to configure multiple entries in `bicepconfig.json` and use different `extension` directives depending on the namespace. This PR is part of a series that consolidates them into the existing `radius` Bicep extension so users have a single `extension radius` for all Radius-authored types.

Specifically, this PR wires up the build pipeline so that contrib resource type manifests (maintained via [`make update-resource-types`](https://github.com/radius-project/radius/pull/11911)) are included in the unified `radius` extension alongside the existing TypeSpec/Swagger-generated types.

## What this PR does

1. **`generate-bicep-types-contrib` Makefile target** -- reads `deploy/manifest/defaults.yaml` to discover which contrib namespaces to include and passes all per-type manifests for each namespace to `manifest-to-bicep generate` for merging into `types.json` + `index.json` + `index.md`.
2. **`publish-bicep-extension` Makefile target** -- wraps `bicep publish-extension` for local testability.
3. **Shared `index-builder.ts` module** -- extracts `buildTypeIndex()` from `generate.ts` into a shared module so both the autorest pipeline and the new `rebuild-index` CLI can use it without code duplication.
4. **`rebuild-index.ts` CLI wrapper** -- standalone entry point that rebuilds the unified `index.json`/`index.md` after contrib `types.json` files are added to the generated tree.
5. **Extended `generate-bicep-types` target** -- now calls `generate-bicep-types-contrib` then `rebuild-index` after the existing autorest step, so the full pipeline produces one unified extension.
6. **Removed contrib extension references** -- `radiusCompute`, `radiusData`, `radiusSecurity` removed from `bicepconfig.json`, `install-bicep.sh`, and `pkg/cli/setup` since these namespaces are now part of the single `radius` extension.

## How the build pipeline works after this PR

```
make generate-bicep-types
  |
  +--> Step 1: autorest pipeline (existing, unchanged)
  |      Generates types from Swagger/TypeSpec for Applications.Core, Applications.Dapr, etc.
  |      Output: generated/radius/applications.core/.../types.json, etc.
  |
  +--> Step 2: generate-bicep-types-contrib (new)
  |      Reads defaults.yaml, runs manifest-to-bicep generate per namespace
  |      Output: generated/radius/radius.compute/.../types.json, etc.
  |
  +--> Step 3: rebuild-index (new)
         Walks the full generated/ tree, builds unified index.json + index.md
         Output: generated/index.json (covers all namespaces from both steps)
```

## Dependencies

- PR 1: [multi-file merge support](https://github.com/kachawla/radius/pull/36)
- [Automated default resource type registration](https://github.com/radius-project/radius/pull/11911) (provides `defaults.yaml` and per-type manifest files)

## Changes

- `build/generate.mk`: New `generate-yq-installed`, `generate-bicep-types-contrib`, and `publish-bicep-extension` targets
- `hack/bicep-types-radius/src/generator/src/index-builder.ts`: New shared module exporting `buildTypeIndex()`
- `hack/bicep-types-radius/src/generator/src/cmd/generate.ts`: Refactored to import `buildTypeIndex` from the shared module instead of defining it inline
- `hack/bicep-types-radius/src/generator/src/cmd/rebuild-index.ts`: New thin CLI wrapper that parses args and calls the shared `buildTypeIndex()`
- `hack/bicep-types-radius/src/generator/package.json`: Added `rebuild-index` script entry
- `bicepconfig.json`, `build/install-bicep.sh`, `pkg/cli/setup/application.go`, `pkg/cli/setup/application_test.go`: Removed contrib extension references

## Part of

Unified Bicep extension publishing (PR 2/4). See [design note](https://github.com/radius-project/radius/blob/main/eng/design-notes/extensibility/2026-05-unified-bicep-extension-publishing.md).